### PR TITLE
ddirch site-level JAGS model selection algorithm

### DIFF
--- a/NEFI_functions/covariate_selection_JAGS.r
+++ b/NEFI_functions/covariate_selection_JAGS.r
@@ -1,0 +1,122 @@
+#' covariate_selection_JAGS
+#' algorithm to perform backwards covariate selection based on JAGS model deviance scores.
+#' Given a model and a set of predictors the algorithm proceeds this way:
+#' Step 1. calculate model deviance with all predictors.
+#' Step 2. Rerun the model without a particular predictor, calculate deviance. Do this for all predictors.
+#' Step 3. Drop the predictor that results in the largest improvement in deviance (apparently this is the greedy part of a greedy algorithm.)
+#' Step 4. Using our new best model, repeat Steps 2 and 3 until:
+#'         (a.) deviance no longer improves,
+#'         (b.) deviance does not improve beyond a threshold change (say 2 units),
+#'         (c.) there are no more predictors to remove.
+#'         
+#' @param y           #matrix of species relative abundances.
+#' @param x_mu        #matrix of covaraites.
+#' @param n.adapt     #number of adaptive iterations.
+#' @param n.burnin    #number of burnin iterations.
+#' @param n.sample    #number of sampling iterations.
+#'
+#' @return            #returns a list of covariates retained, deviance scores of the last comparison, and the JAGS model that is the best.
+#'                    #JAGS model in list is also a list with the full model, model summary, species X parameter tables and predicted/observed/residual matrices.
+#' @export
+#'
+#' @examples
+#' #### generate pseudo data to test ####
+#'n.obs <- 25
+#'x1 <- runif(n.obs,20,40);x2 <- runif(n.obs, 2, 4);x3 <- runif(n.obs,100,110);intercept <- rep(1,n.obs);y <- x1*0.5 + x2*3 + rnorm(n.obs)
+#'y1 <- y;y2 <- rep(10, length(y1));spp.y <- data.frame(cbind(y1,y2));spp.y <- spp.y / rowSums(spp.y)
+#'x_mu <- data.frame(intercept,x1,x2,x3)
+#'test <- covariate_selection_JAGS(y=spp.y, x_mu = x_mu)
+#'
+
+#Function depends on these things.
+library(runjags)
+library(doParallel)
+source('NEFI_functions/ddirch_site.level_JAGS.r')
+source('NEFI_functions/crib_fun.r')
+source('NEFI_functions/tic_toc.r')
+
+covariate_selection_JAGS <- function(y, x_mu, n.adapt = 100, n.burnin = 100, n.sample = 200, parallel = F){
+  #### Fit first JAGS model to all covariates. ####
+  #register parallel cores
+  registerDoParallel(cores = detectCores())
+  
+  #start a loop counter and a done indicator for the while loop.
+  donezo <- 0
+  loop.count <- 1
+  runmode <- ifelse(parallel == F, F, T)
+  
+  #fit first model, calculate deviance.
+  tic()
+  fit <- site.level_dirlichet_jags(y = y, x_mu = x_mu, adapt = n.adapt, burnin = n.burnin, sample = n.sample, parallel = runmode)
+  dev <- fit$deviance #grab deviance
+  cat('Initial model fit complete.')
+  toc()
+  while(donezo < 1){
+    #sequentially leave out one predictor, except intercept.
+    tic()
+    fit.list <- list() 
+    fit.list <-
+      foreach(i = 2:ncol(x_mu)) %dopar% {
+        x_new <- x_mu[,-i]
+        mod.fit <- site.level_dirlichet_jags(y=y, x_mu = x_new, adapt = n.adapt, burnin = n.burnin, sample = n.sample, parallel = runmode)
+        fit.list[[i-1]] <- mod.fit
+      }
+    #grab deviance statistics as data.frame.
+    dev.list <- list()
+    for(i in 1:length(fit.list)){
+      dev.list[[i]] <- fit.list[[i]]$deviance
+    }
+    dev.list <-data.frame(do.call(rbind,dev.list))
+    rownames(dev.list) <- colnames(x_mu)[2:ncol(x_mu)]
+    
+    #calculate difference in deviance scores.
+    dev.list$diff <- dev[4] - dev.list$Mean
+    ###Here I think I should compare deviance distributions, if 95% CI overlaps with reference model deviance, then set difference to zero.
+    #removing predictor that results in the largest improvement in deviance score.
+    max.diff <- max(dev.list$diff)
+    to.drop <- rownames(dev.list[which.max(dev.list$diff),])
+    
+    #report how long current selection loop took to complete.
+    cat('Model selection loop',loop.count,'complete. ')
+    toc()
+    
+    #if the difference is less than 2 or negative you are done.
+    if(max.diff < 2){
+      cat('*Best* model found! results are in output.list. \n')
+      to_keep <- colnames(x_mu)
+      output.list <- list(dev.list, to_keep, fit)
+      names(output.list) <- c('deviance_table','variables','jags_model')
+      donezo <- 1
+      next
+    }
+    
+    #If removing the next predictor brings you to a single predictor remaining, you are done.
+    if(ncol(x_mu) == 3){
+      #Drop the predictor.
+      x_mu <- x_mu[,-which(colnames(x_mu) %in% to.drop)]
+      #Grab the model thats the best.
+      pos <- which(rownames(dev.list) == to.drop)
+      fit <- fit.list[[pos]]
+      #wrap the restof the output.
+      to_keep <- colnames(x_mu)
+      output.list <- list(dev.list, to_keep, fit)
+      names(output.list) <- c('deviance_table','variables','jags_model')
+      #tell R you are done and report.
+      donezo <- 1
+      cat('No more predictors to remove. Returning *best* model. Results in output.list. \n')
+      next
+    }
+    
+    #If dropping the variables improves deviance by more than 2, awesome. Drop it and repeat the procedure!
+    x_mu <- x_mu[,-which(colnames(x_mu) %in% to.drop)]
+    #get new reference model to compare things to.
+    pos <- which(rownames(dev.list) == to.drop)
+    fit <- fit.list[[pos]]
+    dev <- fit$deviance
+    loop.count <- loop.count + 1
+    #tell yourself whats going on.
+    cat(to.drop,'removed from model. Refitting...\n')
+  } #end while loop
+  
+  return(output.list)
+} #end function

--- a/NEFI_functions/covariate_selection_JAGS.r
+++ b/NEFI_functions/covariate_selection_JAGS.r
@@ -35,7 +35,7 @@ source('NEFI_functions/ddirch_site.level_JAGS.r')
 source('NEFI_functions/crib_fun.r')
 source('NEFI_functions/tic_toc.r')
 
-covariate_selection_JAGS <- function(y, x_mu, n.adapt = 100, n.burnin = 100, n.sample = 200, parallel = F){
+covariate_selection_JAGS <- function(y, x_mu, n.adapt = 100, n.burnin = 100, n.sample = 200, parallel = F, silent.jags = T){
   #### Fit first JAGS model to all covariates. ####
   #register parallel cores
   registerDoParallel(cores = detectCores())
@@ -59,7 +59,7 @@ covariate_selection_JAGS <- function(y, x_mu, n.adapt = 100, n.burnin = 100, n.s
     fit.list <-
       foreach(i = 2:ncol(x_mu)) %dopar% {
         x_new <- x_mu[,-i]
-        mod.fit <- site.level_dirlichet_jags(y=y, x_mu = x_new, adapt = n.adapt, burnin = n.burnin, sample = n.sample, parallel = runmode)
+        mod.fit <- site.level_dirlichet_jags(y=y, x_mu = x_new, adapt = n.adapt, burnin = n.burnin, sample = n.sample, parallel = runmode, silent.jags = silent.jags)
         fit.list[[i-1]] <- mod.fit
       }
     #grab deviance statistics as data.frame.

--- a/NEFI_functions/ddirch_site.level_JAGS.r
+++ b/NEFI_functions/ddirch_site.level_JAGS.r
@@ -15,11 +15,10 @@
 #' @export
 #'
 #' @examples
-#' adapt = 500; burnin = 1000; sample = 2000; n.chains = 3; parallel = F
 site.level_dirlichet_jags     <- function(y,
                                           x_mu, 
                                           x_sd = NA,
-                                          adapt = 500, burnin = 1000, sample = 2000, n.chains = 3, parallel = F){
+                                          adapt = 500, burnin = 1000, sample = 2000, n.chains = 3, parallel = F, silent.jags = F){
   #Load some important dependencies.
   source('NEFI_functions/crib_fun.r')
   source('NEFI_functions/sd_to_precision.r')
@@ -129,6 +128,7 @@ site.level_dirlichet_jags     <- function(y,
                                    sample = sample,
                                    n.chains = n.chains,
                                    method = run.method,
+                                   silent.jags = silent.jags,
                                    monitor = c('x.m','deviance'))
   #summarize output
   out <- summary(jags.out)

--- a/analysis/1._priorITS-tedersoo_ddirch_fit.r
+++ b/analysis/1._priorITS-tedersoo_ddirch_fit.r
@@ -12,6 +12,7 @@ source('NEFI_functions/crib_fun.r')
 d <- data.table(readRDS(ted.ITSprior_data))
 d <- d[,.(Ectomycorrhizal,Saprotroph,Pathogen,Arbuscular,cn,pH,moisture,NPP,map,mat,forest,conifer,relEM)]
 d <- d[complete.cases(d),] #optional. This works with missing data.
+#d <- d[1:35,] #for testing
 
 #organize y data
 y <- d[,.(Ectomycorrhizal,Saprotroph,Pathogen,Arbuscular)]

--- a/analysis/covariate_selection/1._ITSprior_linear_all.preds.r
+++ b/analysis/covariate_selection/1._ITSprior_linear_all.preds.r
@@ -1,0 +1,35 @@
+#covariate selection on tedersoo ITSprior.
+#linear combination of as many predictors as we can think of, no interactions.
+#clear environment, load paths and functions.
+rm(list=ls())
+source('NEFI_functions/covariate_selection_JAGS.r')
+source('NEFI_functions/crib_fun.r')
+source('paths.r')
+
+#load data.
+d <- data.table::data.table(readRDS(ted.ITSprior_data))
+d <- d[,.(Ectomycorrhizal,Saprotroph,Pathogen,Arbuscular,cn,pH,moisture,NPP,map,mat,forest,conifer,relEM)]
+d <- d[complete.cases(d),] #optional. This works with missing data.
+d <- d[1:35,] #subset to test.
+
+#organize y data
+y <- d[,.(Ectomycorrhizal,Saprotroph,Pathogen,Arbuscular)]
+#make other column
+y <- data.frame(lapply(y,crib_fun))
+y$other <- 1 - rowSums(y)
+y <- as.data.frame(y)
+#reorder columns. other needs to be first.
+y <- y[c('other','Ectomycorrhizal','Pathogen','Saprotroph','Arbuscular')]
+
+#Drop in intercept, setup predictor matrix.
+d$intercept <- rep(1,nrow(d))
+x <- d[,.(intercept,cn,pH,moisture,NPP,mat,map,forest,conifer,relEM)]
+x$map <- log(x$map)
+y <- as.data.frame(y)
+x <- as.data.frame(x)
+
+#run the algorithm.
+send_it <- covariate_selection_JAGS(y=y,x_mu=x)
+
+#save the output.
+saveRDS(send_it, ITS.prior_linear_fg_cov.selection_JAGS)

--- a/analysis/covariate_selection/1._ITSprior_linear_all.preds.r
+++ b/analysis/covariate_selection/1._ITSprior_linear_all.preds.r
@@ -1,0 +1,35 @@
+#covariate selection on tedersoo ITSprior.
+#linear combination of as many predictors as we can think of, no interactions.
+#clear environment, load paths and functions.
+rm(list=ls())
+source('NEFI_functions/covariate_selection_JAGS.r')
+source('NEFI_functions/crib_fun.r')
+source('paths.r')
+
+#load data.
+d <- data.table::data.table(readRDS(ted.ITSprior_data))
+d <- d[,.(Ectomycorrhizal,Saprotroph,Pathogen,Arbuscular,cn,pH,moisture,NPP,map,mat,forest,conifer,relEM)]
+d <- d[complete.cases(d),] #optional. This works with missing data.
+#d <- d[1:35,] #subset to test.
+
+#organize y data
+y <- d[,.(Ectomycorrhizal,Saprotroph,Pathogen,Arbuscular)]
+#make other column
+y <- data.frame(lapply(y,crib_fun))
+y$other <- 1 - rowSums(y)
+y <- as.data.frame(y)
+#reorder columns. other needs to be first.
+y <- y[c('other','Ectomycorrhizal','Pathogen','Saprotroph','Arbuscular')]
+
+#Drop in intercept, setup predictor matrix.
+d$intercept <- rep(1,nrow(d))
+x <- d[,.(intercept,cn,pH,moisture,NPP,mat,map,forest,conifer,relEM)]
+x$map <- log(x$map)
+y <- as.data.frame(y)
+x <- as.data.frame(x)
+
+#run the algorithm.
+send_it <- covariate_selection_JAGS(y=y,x_mu=x, adapt = 300, burnin = 1000, sample = 1000, parallel = T)
+
+#save the output.
+saveRDS(send_it, ITS.prior_linear_fg_cov.selection_JAGS)

--- a/analysis/covariate_selection/q1._ITSprior_linear_all.preds.txt
+++ b/analysis/covariate_selection/q1._ITSprior_linear_all.preds.txt
@@ -1,0 +1,46 @@
+#!/bin/bash -l
+#
+########################################
+####      commands for scc qsub     ####
+########################################
+#Specfiy hard time limit for the job.
+#$ -l h_rt=80:00:00
+#
+#Use N processors on a single machine. Running 3 chains in parallel, but i think a 4th will make things move better.
+#$ -pe omp 36
+#
+#Give the job a name
+#$ -N cov_ITS_linear
+#
+# Merge stderr into the stdout file, to reduce clutter
+#$ -j y
+#$ -o $JOB_NAME.log
+#
+#
+# Have the system send mail when the job begins and when the job is aborted or ended
+#$ -m ae
+#
+# Inherit the current environment (load modules python/2.7.7, qiime, and find binaries)
+# Make sure th load those modules in the command line before you submit the qsub
+#$ -V 
+#
+# end of qsub arguments
+#
+########################################
+#### begin commands to run R script ####
+########################################
+#
+#
+# load necessary modules 
+module load R/3.4.0
+module load jags
+#
+# cd into directory, for safety purposes
+cd /project/talbot-lab-data/caverill/NEFI_microbe
+#
+# in the directory specified above, invoke this function:
+Rscript analysis/covariate_selection/1._ITSprior_linear_all.preds.r
+#
+#
+#End of commands.
+#

--- a/paths.r
+++ b/paths.r
@@ -24,6 +24,7 @@ dir <- paste0(data.dir,'JAGS_output/')
 cmd <- paste0('mkdir -p ',dir)
 system(cmd)
 ted_ITS.prior_fg_JAGSfit <- paste0(dir,'ted_ITS.prior_fg_JAGSfit.rds')
+ITS.prior_linear_fg_cov.selection_JAGS <- paste0(dir,'ITS.prior_linear_fg_cov.selection_JAGS.rds')
 
 #Tedersoo ITS prior paths
 dir <- paste0(data.dir,'prior_data/')

--- a/testing_development/proving ddirch models work.r
+++ b/testing_development/proving ddirch models work.r
@@ -70,7 +70,8 @@ mtext(paste0('R2 = ',round(summary(m1)$r.squared, 2)), side = 3, adj = 0.05, lin
 
 #### testing site level dirichlet w/ pseudo data ####
 source('testing_development/implement_missing_data_ddirch/ddirch_missing.data_site.level.only_function.r')
-test <- site.level_dirlichet_jags(y=spp.y,x_mu=test.x,adapt = 100, burnin = 200, sample = 200)
+#source('NEFI_functions/ddirch_site.level_JAGS.r')
+test <- site.level_dirlichet_jags(y=spp.y,x_mu=test.x,adapt = 100, burnin = 200, sample = 200, silent.jags = T)
 
 #plot predicted vs. observed, 1:1 line, vest fit line and R2 values.
 par(mfrow = c(1,2))


### PR DESCRIPTION
Wrote code to fit a JAGS model, calculate deviance, then fit that same model N times, leaving each predictor out one at a time (except the intercept). The algorithm then recalculates deviance, compares to full model, then drops the covariate that improves model deviance the most. This new model is now used as the reference model, and we perform model selection again. This loop iterates until either deviance no longer improves or there are no more predictors to remove.

The algorithm works and takes ~1 day. This could go ~3x faster if I could get multi-node processing working via rMPI.

My model comparison metric is wrong, but this proves that the algorithm works. I now need to convert deviance into an actual model comparison metric.